### PR TITLE
Remove Holo theme remainees from the app

### DIFF
--- a/DroidFishApp/src/main/AndroidManifest.xml
+++ b/DroidFishApp/src/main/AndroidManifest.xml
@@ -10,13 +10,13 @@
 
     <application android:name="org.petero.droidfish.DroidFishApp"
                  android:icon="@mipmap/icon"
-                 android:theme="@android:style/Theme.Holo"
+                 android:theme="@style/AppTheme"
                  android:label="@string/app_name"
                  android:allowBackup="true"
                  android:resizeableActivity="true">
         <activity android:name=".DroidFish"
                   android:label="@string/app_name"
-                  android:theme="@android:style/Theme.Holo.NoActionBar"
+                  android:theme="@style/MainActivityTheme"
                   android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/DroidFishApp/src/main/res/values/styles.xml
+++ b/DroidFishApp/src/main/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat">
+        <item name="colorPrimary">#000000</item>
+        <item name="colorPrimaryDark">#000000</item>
+    </style>
+
+    <style name="MainActivityTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="colorPrimary">#000000</item>
+        <item name="colorPrimaryDark">#000000</item>
+    </style>
+</resources>


### PR DESCRIPTION
Most obvious change will be making the dialog like this,
![image](https://user-images.githubusercontent.com/833473/56475665-82972800-64a0-11e9-9c17-91c13a2be133.png)
Which is considered the new theme of Android apps.