### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ settings, open the UCI options editor and click `RESET` and `OK`.
   * For Windows and Linux, install the Engine server software from the
     [DroidFish](http://hem.bredband.net/petero2b/droidfish/index.html) page.
 
-  * Alternatively for Linux, `mini-inetd` from the `tcputils` package can be
+  * Alternatively for Linux, `mini-inetd` from the `tcputils` package or `netcat` from the `netcat-traditional` package can be
     used.
 
 * Select *Manage Chess Engines* in the *Left drawer menu*, create a new network


### PR DESCRIPTION
Add `netcat` to README.md as a alternative way to initialize remote engine.

Can be used as below:
```sh
netcat --local-port=<PORT> --listen --exec=<STOCKFISH_EXECUTABLE_FILE>
```